### PR TITLE
Reduce barcode card height by 2mm for more reliable 3-row A4 printing

### DIFF
--- a/extra-barcodes.html
+++ b/extra-barcodes.html
@@ -15,7 +15,8 @@
       --radius: 2.5mm;
       --rows-per-page: 3;
       --page-print-height: 277mm; /* A4 height (297mm) minus @page top+bottom margins (10mm each) */
-      --card-height: calc((var(--page-print-height) - (var(--gap) * (var(--rows-per-page) - 1))) / var(--rows-per-page));
+      --card-height-tweak: 2mm; /* shrink cards slightly so 3 rows fit more reliably when printing */
+      --card-height: calc(((var(--page-print-height) - (var(--gap) * (var(--rows-per-page) - 1))) / var(--rows-per-page)) - var(--card-height-tweak));
       --font: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
     }
 


### PR DESCRIPTION
### Motivation
- Three barcode rows on A4 were occasionally too tight and could overflow when printing, so each card height is reduced slightly to give consistent headroom.

### Description
- In `extra-barcodes.html` add `--card-height-tweak: 2mm` and subtract it from the existing `--card-height` calculation in the `:root` CSS so each card is 2mm shorter.

### Testing
- No automated tests were run for this static HTML/CSS tweak.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba81aa024c832b9c865cf95afb69be)