### PR TITLE
Alphabet Trainer v2

### DIFF
--- a/alphabet.html
+++ b/alphabet.html
@@ -602,7 +602,7 @@
       if (state.prompt.kind === "N2L") {
         const c = v.trim();
         if (c.length >= 1 && /^[A-Za-z]$/.test(c)) submit(c);
-      } else if (state.prompt.kind === "L2N") {
+      } else if (state.prompt.kind === "L2N" || state.prompt.kind === "WORD") {
         const c = v.trim();
         if (c.length === state.prompt.answer.length) submit(c);
       }

--- a/alphabet.html
+++ b/alphabet.html
@@ -572,8 +572,10 @@
         el.prompt.textContent = prompt.question;
         el.prompt.classList.toggle("word", prompt.kind === "WORD");
         el.input.disabled = inputDisabled;
-        el.input.inputMode = prompt.kind === "L2N" ? "numeric" : "text";
-        el.input.maxLength = prompt.kind === "WORD" ? 20 : (prompt.kind === "L2N" ? 3 : 2);
+        const newInputMode = prompt.kind === "L2N" ? "numeric" : "text";
+        if (el.input.inputMode !== newInputMode) el.input.inputMode = newInputMode;
+        const newMaxLength = prompt.kind === "WORD" ? 20 : (prompt.kind === "L2N" ? 3 : 2);
+        if (el.input.maxLength !== newMaxLength) el.input.maxLength = newMaxLength;
       }
 
       // Action button

--- a/alphabet.html
+++ b/alphabet.html
@@ -602,6 +602,9 @@
       if (state.prompt.kind === "N2L") {
         const c = v.trim();
         if (c.length >= 1 && /^[A-Za-z]$/.test(c)) submit(c);
+      } else if (state.prompt.kind === "L2N") {
+        const c = v.trim();
+        if (c.length === state.prompt.answer.length) submit(c);
       }
     });
 


### PR DESCRIPTION
Rewrites the alphabet trainer as a vanilla JS/CSS single-file app (no React, no CDN dependencies) and adds several UX improvements.

## Changes

- **Vanilla JS rewrite** — removes React + Babel CDN, eliminates parse delay on mobile
- **Auto-submit for all modes** — N2L submits on single letter; L2N submits when digit count matches expected (1 digit for A–I, 2 for J–Z); Word submits when typed length matches the answer
- **iOS caps lock fix** — `inputMode` and `maxLength` are only written to the DOM when the value changes, preventing Safari from resetting keyboard state between prompts

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQ7TGSwbFFq8y99QpbBPnr)_