### PR TITLE
Fix practice countdown visibility and word mode behaviour

### DIFF
--- a/alphabet.html
+++ b/alphabet.html
@@ -554,6 +554,8 @@
 
     function startPromptTimer() {
       clearInterval(practiceTimerId);
+      practiceTimerId = null;
+      if (state.prompt.kind === "WORD") return;
       state.practiceTimeLeft = 5;
       promptShownAt = Date.now();
       render();

--- a/alphabet.html
+++ b/alphabet.html
@@ -109,6 +109,15 @@
 }
 .feedback .ok { color: #15803d; }
 .feedback .bad { color: #b91c1c; }
+.prompt-timer {
+  height: 20px;
+  margin-top: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  color: #a8a29e;
+}
+.prompt-timer.warn { color: #c2410c; }
 
 /* Result screen */
 .result {
@@ -284,6 +293,7 @@
       inputmode="text"
     />
     <div class="feedback" id="feedback"></div>
+    <div class="prompt-timer" id="promptTimer"></div>
   </div>
 </div>
 
@@ -442,6 +452,7 @@
       prompt: document.getElementById("prompt"),
       input: document.getElementById("input"),
       feedback: document.getElementById("feedback"),
+      promptTimer: document.getElementById("promptTimer"),
       pills: document.getElementById("pills"),
       modeToggle: document.getElementById("modeToggle"),
       statusReadout: document.getElementById("statusReadout"),
@@ -659,16 +670,23 @@
         btn.classList.toggle("active", btn.dataset.key === mode);
       });
 
-      // Status readout
+      // Status readout — sprint timer only; practice countdown lives in the stage
       if (mode === "SPRINT") {
         const mins = Math.floor(timeLeft / 60);
         const secs = String(timeLeft % 60).padStart(2, "0");
         const warn = timeLeft <= 10 && sprintActive;
         el.statusReadout.innerHTML = `<div class="timer ${warn ? "warn" : ""}">${mins}:${secs}</div>`;
-      } else if (practiceActive) {
-        el.statusReadout.innerHTML = `<div class="timer ${practiceTimeLeft <= 2 ? "warn" : ""}">${practiceTimeLeft}s</div>`;
       } else {
         el.statusReadout.innerHTML = "";
+      }
+
+      // Practice countdown (below input, stays above keyboard)
+      if (mode === "PRACTICE" && practiceActive) {
+        el.promptTimer.textContent = `${practiceTimeLeft}s`;
+        el.promptTimer.className = `prompt-timer${practiceTimeLeft <= 2 ? " warn" : ""}`;
+      } else {
+        el.promptTimer.textContent = "";
+        el.promptTimer.className = "prompt-timer";
       }
 
       // Stage panels

--- a/alphabet.html
+++ b/alphabet.html
@@ -102,9 +102,9 @@
 .input:focus { border-bottom-color: #1c1917; }
 .input:disabled { opacity: 0.4; }
 .feedback {
-  height: 24px;
+  height: 36px;
   margin-top: 12px;
-  font-size: 14px;
+  font-size: 28px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 .feedback .ok { color: #15803d; }


### PR DESCRIPTION
## Summary

- **Timer placement**: moved the 5 s per-prompt countdown out of the toolbar `statusReadout` (hidden behind the mobile keyboard) and into the stage area, below the feedback line — always visible while typing.
- **Word mode**: the countdown no longer runs for word prompts. Word practice continues indefinitely with no timeout pressure.

## Test plan

- [ ] Open Practice mode on mobile — confirm the countdown is visible above the keyboard while answering
- [ ] Let the countdown reach 0 — confirm practice stops and returns to Start screen
- [ ] Switch to Word direction, tap Start — confirm no countdown appears and session doesn't auto-stop

https://claude.ai/code/session_01AQ7TGSwbFFq8y99QpbBPnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQ7TGSwbFFq8y99QpbBPnr)_