### PR TITLE
Fix adaptive weighting and add clear stats button

### DIFF
--- a/alphabet.html
+++ b/alphabet.html
@@ -851,10 +851,19 @@
           <div class="stats-section-title">Letter → Number</div>
           <div class="stats-grid">${LETTERS.map(l => cell("L2N", l)).join("")}</div>
         </div>
+        <button class="btn-secondary" id="statsClear">Clear all stats</button>
       `;
       document.getElementById("statsClose").addEventListener("click", () => {
         state.statsOpen = false;
         render();
+      });
+      document.getElementById("statsClear").addEventListener("click", () => {
+        if (!confirm("Clear all stats and sprint bests?")) return;
+        letterStats = { N2L: emptyProfile(), L2N: emptyProfile() };
+        sprintBests = [];
+        localStorage.removeItem("alphabet-trainer-stats");
+        localStorage.removeItem("alphabet-trainer-sprints");
+        renderStats();
       });
     }
 

--- a/alphabet.html
+++ b/alphabet.html
@@ -431,19 +431,12 @@
     let letterStats = loadStats();
 
     function computeWeights(kind) {
-      const entries = Array.from({ length: 26 }, (_, i) => {
+      return Array.from({ length: 26 }, (_, i) => {
         const letter = String.fromCharCode(65 + i);
         const s = letterStats[kind][letter] || { a: 0, w: 0, t: 0 };
-        const correct = s.a - s.w;
         const errorRate = s.a > 0 ? s.w / s.a : 0;
-        const avgTime = correct > 0 ? s.t / correct : 0;
-        return { errorRate, avgTime, attempts: s.a };
-      });
-      const maxAvgTime = Math.max(...entries.map(e => e.avgTime), 1);
-      return entries.map(({ errorRate, avgTime, attempts }) => {
-        const confidence = Math.min(attempts / MIN_ATTEMPTS, 1);
-        const normTime = avgTime / maxAvgTime;
-        return 1 + confidence * (errorRate * 2 + normTime * 2);
+        const confidence = Math.min(s.a / MIN_ATTEMPTS, 1);
+        return 1 + confidence * errorRate * 4;
       });
     }
 


### PR DESCRIPTION
## Summary

- **Fix adaptive weighting**: the previous formula included a normalised average response time term, but `avgTime` was only computed from *correct* answers. A letter you always get wrong has no correct answers, so `avgTime = 0` and the time component contributed nothing — meaning a slow-but-occasionally-correct letter could outrank an always-wrong letter. The time component is dropped; selection is now driven purely by error rate: `weight = 1 + confidence × errorRate × 4`, giving up to 5× baseline for a letter with 100% error rate and ≥ 4 attempts. Timing is still recorded and shown in the stats view.
- **Clear stats button**: a "Clear all stats" button at the bottom of the stats view prompts for confirmation then wipes both per-letter stats and sprint bests from memory and localStorage.

## Test plan

- [ ] Practice N→L, deliberately get one letter wrong several times — confirm it appears noticeably more often after ~4 attempts
- [ ] Open Stats — letter grids should reflect the accumulated errors
- [ ] Tap "Clear all stats", confirm → stats grid resets to all dimmed, sprint bests cleared
- [ ] Cancel on the confirm prompt → nothing changes

https://claude.ai/code/session_01AQ7TGSwbFFq8y99QpbBPnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQ7TGSwbFFq8y99QpbBPnr)_