### PR TITLE
alphabet: match stop button to start button styling, mute disabled session toggle

### DIFF
--- a/alphabet.html
+++ b/alphabet.html
@@ -273,6 +273,7 @@
   background: #1c1917;
   color: #fafaf9;
 }
+.mode-btn:disabled { opacity: 0.4; }
 .timer {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 18px;
@@ -943,7 +944,7 @@
           el.actionBtn.onclick = () => { if (state.mode === "SPRINT") startSprint(); else startPractice(); };
         } else {
           el.actionBtn.textContent = "Stop";
-          el.actionBtn.className = "btn-secondary";
+          el.actionBtn.className = "btn-primary";
           el.actionBtn.onclick = mode === "SPRINT" ? endSprint : () => { stopPractice(); render(); };
         }
       }


### PR DESCRIPTION
- Stop button now uses btn-primary (white on black, same size as Start)
- Session type toggle buttons get opacity: 0.4 when disabled, matching pill button disabled style

https://claude.ai/code/session_01Y5eS6zcJxPKzgU2H3EYfZe