### PR TITLE
Refactor alphabet trainer state reset and localStorage handling

### DIFF
--- a/alphabet.html
+++ b/alphabet.html
@@ -484,6 +484,13 @@
     // ============ Constants ============
     const DIRECTIONS = { N2L: "N→L", L2N: "L→N", MIX: "Mix", WORD: "Word" };
     const MODES = { PRACTICE: "Practice", SPRINT: "Sprint" };
+    const STORAGE_KEYS = {
+      STATS: "alphabet-trainer-stats",
+      SPRINT_BESTS: "alphabet-trainer-sprints",
+      SPRINT_SUMMARIES: "alphabet-trainer-sprint-summaries",
+    };
+    const INITIAL_RUN_STATS = { correct: 0, wrong: 0, streak: 0, best: 0 };
+    const TIMEOUT_OPTIONS = { DEFAULT: [5, 10, 20], WORD: [10, 30, 60] };
 
     const WORDS = [
       "cat","dog","run","sky","owl","tea","map","pen","jar","fox",
@@ -509,20 +516,25 @@
       );
     }
 
-    function loadStats() {
+    function loadStoredObject(key) {
       try {
-        const raw = JSON.parse(localStorage.getItem("alphabet-trainer-stats") || "{}");
-        return {
-          N2L: { ...emptyProfile(), ...(raw.N2L || {}) },
-          L2N: { ...emptyProfile(), ...(raw.L2N || {}) },
-        };
+        const parsed = JSON.parse(localStorage.getItem(key) || "{}");
+        return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
       } catch {
-        return { N2L: emptyProfile(), L2N: emptyProfile() };
+        return {};
       }
     }
 
+    function loadStats() {
+      const raw = loadStoredObject(STORAGE_KEYS.STATS);
+      return {
+        N2L: { ...emptyProfile(), ...(raw.N2L || {}) },
+        L2N: { ...emptyProfile(), ...(raw.L2N || {}) },
+      };
+    }
+
     function saveStats() {
-      localStorage.setItem("alphabet-trainer-stats", JSON.stringify(letterStats));
+      localStorage.setItem(STORAGE_KEYS.STATS, JSON.stringify(letterStats));
     }
 
     let letterStats = loadStats();
@@ -548,31 +560,20 @@
       return 26;
     }
 
-    let sprintBests = (() => {
-      try {
-        const raw = JSON.parse(localStorage.getItem("alphabet-trainer-sprints") || "{}");
-        return Array.isArray(raw) ? {} : raw;
-      } catch { return {}; }
-    })();
-
-    let sprintSummaries = (() => {
-      try {
-        const raw = JSON.parse(localStorage.getItem("alphabet-trainer-sprint-summaries") || "{}");
-        return Array.isArray(raw) ? {} : raw;
-      } catch { return {}; }
-    })();
+    let sprintBests = loadStoredObject(STORAGE_KEYS.SPRINT_BESTS);
+    let sprintSummaries = loadStoredObject(STORAGE_KEYS.SPRINT_SUMMARIES);
 
     function saveSprintBest(direction, correct, wrong) {
       const cur = sprintBests[direction];
       if (!cur || correct > cur.c || (correct === cur.c && wrong < cur.w)) {
         sprintBests[direction] = { c: correct, w: wrong };
-        localStorage.setItem("alphabet-trainer-sprints", JSON.stringify(sprintBests));
+        localStorage.setItem(STORAGE_KEYS.SPRINT_BESTS, JSON.stringify(sprintBests));
       }
     }
 
     function saveSprintSummary(mode, direction, summary) {
       sprintSummaries[`${mode}:${direction}`] = summary;
-      localStorage.setItem("alphabet-trainer-sprint-summaries", JSON.stringify(sprintSummaries));
+      localStorage.setItem(STORAGE_KEYS.SPRINT_SUMMARIES, JSON.stringify(sprintSummaries));
     }
 
     function recordAttempt(kind, letter, correct, elapsedMs) {
@@ -609,7 +610,7 @@
       mode: "PRACTICE",
       direction: "N2L",
       prompt: makePrompt("N2L"),
-      stats: { correct: 0, wrong: 0, streak: 0, best: 0 },
+      stats: { ...INITIAL_RUN_STATS },
       sprintActive: false,
       timeLeft: 60,
       practiceActive: false,
@@ -642,7 +643,6 @@
       promptTimer: document.getElementById("promptTimer"),
       pills: document.getElementById("pills"),
       modeToggle: document.getElementById("modeToggle"),
-      statusReadout: document.getElementById("statusReadout"),
       timeoutRow: document.getElementById("timeoutRow"),
       actionRow: document.getElementById("actionRow"),
       actionBtn: document.getElementById("actionBtn"),
@@ -695,7 +695,7 @@
     }
 
     function startSprint() {
-      state.stats = { correct: 0, wrong: 0, streak: 0, best: 0 };
+      state.stats = { ...INITIAL_RUN_STATS };
       state.timeLeft = 60;
       state.sprintActive = true;
       state.prompt = makePrompt(state.direction);
@@ -732,7 +732,7 @@
         timerId = null;
       }
       state.timeLeft = 60;
-      state.stats = { correct: 0, wrong: 0, streak: 0, best: 0 };
+      state.stats = { ...INITIAL_RUN_STATS };
       state.prompt = makePrompt(state.direction);
       el.input.value = "";
       clearFeedback();
@@ -740,7 +740,7 @@
     }
 
     function startPractice() {
-      state.stats = { correct: 0, wrong: 0, streak: 0, best: 0 };
+      state.stats = { ...INITIAL_RUN_STATS };
       state.practiceActive = true;
       state.prompt = makePrompt(state.direction);
       el.input.value = "";
@@ -776,7 +776,7 @@
     }
 
     function reset() {
-      state.stats = { correct: 0, wrong: 0, streak: 0, best: 0 };
+      state.stats = { ...INITIAL_RUN_STATS };
       state.prompt = makePrompt(state.direction);
       el.input.value = "";
       clearFeedback();
@@ -927,7 +927,7 @@
       const showTimeout = mode === "PRACTICE" && !practiceActive;
       el.timeoutRow.classList.toggle("hidden", !showTimeout);
       if (showTimeout) {
-        const opts = direction === "WORD" ? [10, 30, 60] : [5, 10, 20];
+        const opts = direction === "WORD" ? TIMEOUT_OPTIONS.WORD : TIMEOUT_OPTIONS.DEFAULT;
         const active = direction === "WORD" ? state.wordTimeout : state.practiceTimeout;
         el.timeoutRow.innerHTML = opts.map(t =>
           `<button class="timeout-btn${active === t ? " active" : ""}" data-t="${t}">${t === 60 ? "1m" : t + "s"}</button>`
@@ -1010,9 +1010,9 @@
         letterStats = { N2L: emptyProfile(), L2N: emptyProfile() };
         sprintBests = {};
         sprintSummaries = {};
-        localStorage.removeItem("alphabet-trainer-stats");
-        localStorage.removeItem("alphabet-trainer-sprints");
-        localStorage.removeItem("alphabet-trainer-sprint-summaries");
+        localStorage.removeItem(STORAGE_KEYS.STATS);
+        localStorage.removeItem(STORAGE_KEYS.SPRINT_BESTS);
+        localStorage.removeItem(STORAGE_KEYS.SPRINT_SUMMARIES);
         renderStats();
       });
     }


### PR DESCRIPTION
### Motivation
- Reduce repetition and fragile string literals for localStorage keys by centralizing them into a single constant (`STORAGE_KEYS`).
- Make persisted-data loading more robust by adding a safe parser to avoid repeated `JSON.parse` try/catch blocks and array-vs-object edge cases.
- Improve consistency for run-state resets and timeout options by extracting shared constants to avoid duplicated inline literals.

### Description
- Added `STORAGE_KEYS`, `loadStoredObject`, `INITIAL_RUN_STATS`, and `TIMEOUT_OPTIONS` constants and wired them into the app initialization and render flow.
- Replaced repeated `localStorage` key usages with `STORAGE_KEYS` and replaced ad-hoc JSON parsing with `loadStoredObject` for `letterStats`, `sprintBests`, and `sprintSummaries`.
- Replaced multiple inline run-stat reset objects with `INITIAL_RUN_STATS` and reused it in `startSprint`, `endSprint`, `startPractice`, and `reset` flows.
- Replaced hard-coded timeout arrays in `render()` with `TIMEOUT_OPTIONS` and removed an unused DOM reference to `statusReadout` from the `el` map.

### Testing
- Verified new constants and references with a code search using `rg` which reported the expected replacements and usages (success).
- Applied the patch to `alphabet.html` and confirmed the file was updated successfully (success).
- Performed a repository status check to ensure the working tree reflected the change (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf19f55e8832b8fb60704b325e8de)