### PR TITLE
Move Pick 4 choices to bottom of play area

### DIFF
--- a/alphabet.html
+++ b/alphabet.html
@@ -123,6 +123,10 @@
   font-weight: 700;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
+.stage-choices {
+  margin-top: auto;
+  margin-bottom: 8px;
+}
 .choice-btn:active { background: #f5f5f4; }
 .feedback {
   height: 36px;
@@ -506,8 +510,8 @@
     />
     <div class="feedback" id="feedback"></div>
     <div class="prompt-timer" id="promptTimer"></div>
-    <div class="choices hidden" id="choices"></div>
   </div>
+  <div class="choices stage-choices hidden" id="choices"></div>
 </div>
 
 <!-- Bottom controls -->


### PR DESCRIPTION
### Motivation
- Visually anchor the Pick 4 answer buttons to the bottom of the play area so choice buttons appear lower on-screen during play for better ergonomics.

### Description
- Updated `alphabet.html` to move the `<div class="choices" id="choices">` out of the `.stage-inner` prompt block to render after it, and added a `.stage-choices` CSS helper (`margin-top: auto; margin-bottom: 8px;`) to position the grid at the bottom. The runtime logic for showing/hiding and populating choices was not changed.

### Testing
- Inspected the changes with `git diff` and file inspection to verify only the intended HTML/CSS edits were included and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f103d589fc832b81712693965de4ed)