### PR TITLE
Fix pick four choices position at bottom of play area

### DIFF
--- a/alphabet.html
+++ b/alphabet.html
@@ -69,6 +69,7 @@
 .stage-inner {
   width: 100%;
   text-align: center;
+  flex: 1;
 }
 .prompt {
   font-weight: 900;


### PR DESCRIPTION
Give .stage-inner flex:1 so it fills available stage height,
which reliably places .choices at the bottom regardless of
how much space the prompt content occupies.

https://claude.ai/code/session_015znoayjmrBgT9KfhwRH4yq