### PR TITLE
Fix pick four position and vertically centre prompt

### DIFF
--- a/alphabet.html
+++ b/alphabet.html
@@ -70,6 +70,10 @@
   width: 100%;
   text-align: center;
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 0;
 }
 .prompt {
   font-weight: 900;
@@ -93,6 +97,7 @@
   width: 100%;
   max-width: 320px;
   text-align: center;
+  align-self: center;
   font-size: 30px;
   font-weight: 700;
   letter-spacing: 0.1em;


### PR DESCRIPTION
## Summary

- **Fix pick four choices at bottom of play area** — gives `.stage-inner` `flex: 1` so it fills the available stage height, which reliably pushes `.choices` to the bottom (previous `margin-top: auto` approach was unreliable without an explicit space to absorb)
- **Vertically centre the prompt** — makes `.stage-inner` a flex column with `justify-content: center` so the prompt/input block sits in the middle of available space rather than the top; also adds `align-self: center` to `.input` to keep it horizontally centred (needed because `align-items` is left as `stretch` to preserve `fitWordPrompt()` width measurement)

## Mobile keyboard

`100dvh` + `interactive-widget=resizes-content` already shrinks the layout when the soft keyboard appears. With `justify-content: center`, the prompt stays centred in whatever space remains above the keyboard — no JS changes needed.

## Test plan

- [ ] Practice (type mode): prompt and input appear vertically centred in the play area
- [ ] Mobile / DevTools emulation with keyboard open: prompt stays centred in the visible area, not pushed to the top
- [ ] Pick 4 mode: prompt is centred above the four choice buttons, choices are at the very bottom of the play area
- [ ] Word direction: multi-line prompts still auto-size to fit the width
- [ ] Feedback and timer text remain horizontally centred after an answer

https://claude.ai/code/session_015znoayjmrBgT9KfhwRH4yq

---
_Generated by [Claude Code](https://claude.ai/code/session_015znoayjmrBgT9KfhwRH4yq)_